### PR TITLE
feat: adding auth

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,13 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders = [
+                'appAuthRedirectScheme': 'com.m.androidnativeapp'
+        ]
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     buildTypes {
         release {
@@ -34,4 +41,5 @@ dependencies {
     implementation 'com.elpassion.android.commons:recycler:0.0.21'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'net.openid:appauth:0.7.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.m.androidNativeApp">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -11,16 +12,25 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-        <activity android:name="com.m.androidNativeApp.MainActivity">
+        android:theme="@style/AppTheme"
+        tools:ignore="GoogleAppIndexingWarning">
+        <activity
+            android:name="com.m.helper.LoginActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="com.m.androidNativeApp.MainActivity">
+            <intent-filter>
+                <action android:name="com.m.androidNativeApp.MainActivity" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <activity
-            android:name=".CreateTask"
+            android:name="com.m.helper.CreateTask"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="com.m.androidNativeApp.CreateTask"/>

--- a/app/src/main/assets/config/mobile-services.json
+++ b/app/src/main/assets/config/mobile-services.json
@@ -1,29 +1,29 @@
 {
-  "clientId": "myapp",
-  "namespace": "mobile-console",
+  "clientId": "androidapp",
+  "namespace": "mobile-developer-console",
   "services": [
     {
-    "config": {
-      "websocketUrl": "ws://example.com/graphql"
+      "config": {
+        "auth-server-url": "https://sso-user-sso.apps.ire-85ac.open.redhat.com/auth",
+        "confidential-port": 0,
+        "public-client": true,
+        "realm": "androidapp-realm",
+        "resource": "androidapp-client",
+        "ssl-required": "external"
       },
-    "id": "cc82a0c8-e68c-11e9-af1c-0800270766f9",
-    "name": "sync-app",
-    "type": "sync-app",
-    "url": "https://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-85ac.open.redhat.com/graphql"
+      "id": "4a54df0d-007d-11ea-88e3-022694327861",
+      "name": "keycloak",
+      "type": "keycloak",
+      "url": "https://sso-user-sso.apps.ire-85ac.open.redhat.com/auth"
     },
     {
-    "config": {
-      "auth-server-url": "https://sso-user-sso.apps.ire-586a.open.redhat.com/auth",
-      "confidential-port": 0,
-      "public-client": true,
-      "realm": "frontpage-app-realm",
-      "resource": "frontpage-app-client",
-      "ssl-required": "external"
+      "config": {
+        "websocketUrl": "wss://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-85ac.open.redhat.com/graphql"
       },
-    "id": "1fafffec-f001-11e9-9081-0a07b338f92c",
-    "name": "keycloak",
-    "type": "keycloak",
-    "url": "https://sso-user-sso.apps.ire-586a.open.redhat.com/auth"
+      "id": "94dcaf15-fbd3-11e9-8869-022694327861",
+      "name": "sync-app",
+      "type": "sync-app",
+      "url": "https://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-85ac.open.redhat.com/graphql"
     },
     {
       "config": {

--- a/app/src/main/java/com/m/androidNativeApp/MainActivity.java
+++ b/app/src/main/java/com/m/androidNativeApp/MainActivity.java
@@ -188,7 +188,6 @@ public class MainActivity extends AppCompatActivity {
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        subscribeToDeleteTask();
                         itemAdapter.notifyDataSetChanged();
                     }
                 });

--- a/app/src/main/java/com/m/androidNativeApp/MainActivity.java
+++ b/app/src/main/java/com/m/androidNativeApp/MainActivity.java
@@ -47,12 +47,7 @@ public class MainActivity extends AppCompatActivity {
         setupClient();
         itemAdapter = getAdapter();
 
-        MainActivity.this.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                recyclerView.setAdapter(itemAdapter);
-            }
-        });
+        MainActivity.this.runOnUiThread(() -> recyclerView.setAdapter(itemAdapter));
 
         getTasks();
         subscribeToAddTask();
@@ -74,12 +69,7 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
 
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        itemAdapter.notifyDataSetChanged();
-                    }
-                });
+                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
 
             }
 
@@ -118,12 +108,7 @@ public class MainActivity extends AppCompatActivity {
                 TaskFields dataReceived = response.data().taskAdded().fragments().taskFields;
                 itemList.add(new Item(dataReceived.title(), dataReceived.description(), dataReceived.id()));
 
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        itemAdapter.notifyDataSetChanged();
-                    }
-                });
+                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
             }
 
             @Override
@@ -173,12 +158,7 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
 
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        itemAdapter.notifyDataSetChanged();
-                    }
-                });
+                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
 
             }
 
@@ -214,12 +194,7 @@ public class MainActivity extends AppCompatActivity {
                     taskId = dataReceived.id();
                     itemList.add(new Item(taskTitle, taskDescription, taskId));
                 }
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        itemAdapter.notifyDataSetChanged();
-                    }
-                });
+                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
             }
 
             @Override
@@ -244,7 +219,7 @@ public class MainActivity extends AppCompatActivity {
 
     public ItemAdapter getAdapter(){
         itemList = new ArrayList<>();
-        recyclerView = (RecyclerView) findViewById(R.id.recyclerView);
+        recyclerView = findViewById(R.id.recyclerView);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         itemAdapter = new ItemAdapter(this, itemList);
 

--- a/app/src/main/java/com/m/helper/Auth/AuthStateManager.java
+++ b/app/src/main/java/com/m/helper/Auth/AuthStateManager.java
@@ -1,0 +1,152 @@
+package com.m.helper.Auth;
+
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import androidx.annotation.AnyThread;
+import androidx.annotation.NonNull;
+
+import net.openid.appauth.AuthState;
+import net.openid.appauth.AuthorizationException;
+import net.openid.appauth.AuthorizationResponse;
+import net.openid.appauth.RegistrationResponse;
+import net.openid.appauth.TokenResponse;
+
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONException;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class AuthStateManager {
+
+    private static final AtomicReference<WeakReference<AuthStateManager>> INSTANCE_REF =
+            new AtomicReference<>(new WeakReference<>(null));
+
+    private static final String TAG = "AuthStateManager";
+
+    private static final String STORE_NAME = "AuthState";
+    private static final String KEY_STATE = "state";
+
+    private final SharedPreferences mPrefs;
+    private final ReentrantLock mPrefsLock;
+    private final AtomicReference<AuthState> mCurrentAuthState;
+
+    @AnyThread
+    public static AuthStateManager getInstance(@NonNull Context context) {
+        AuthStateManager manager = INSTANCE_REF.get().get();
+        if (manager == null) {
+            manager = new AuthStateManager(context.getApplicationContext());
+            INSTANCE_REF.set(new WeakReference<>(manager));
+        }
+
+        return manager;
+    }
+
+    private AuthStateManager(Context context) {
+        mPrefs = context.getSharedPreferences(STORE_NAME, Context.MODE_PRIVATE);
+        mPrefsLock = new ReentrantLock();
+        mCurrentAuthState = new AtomicReference<>();
+    }
+
+    @AnyThread
+    @NonNull
+    public AuthState getCurrent() {
+        if (mCurrentAuthState.get() != null) {
+            return mCurrentAuthState.get();
+        }
+
+        AuthState state = readState();
+        if (mCurrentAuthState.compareAndSet(null, state)) {
+            return state;
+        } else {
+            return mCurrentAuthState.get();
+        }
+    }
+
+    @AnyThread
+    @NonNull
+    public AuthState replace(@NonNull AuthState state) {
+        writeState(state);
+        mCurrentAuthState.set(state);
+        return state;
+    }
+
+    @AnyThread
+    @NonNull
+    public AuthState updateAfterAuthorization(
+            @Nullable AuthorizationResponse response,
+            @Nullable AuthorizationException ex) {
+        AuthState current = getCurrent();
+        current.update(response, ex);
+        return replace(current);
+    }
+
+    @AnyThread
+    @NonNull
+    public AuthState updateAfterTokenResponse(
+            @Nullable TokenResponse response,
+            @Nullable AuthorizationException ex) {
+        AuthState current = getCurrent();
+        current.update(response, ex);
+        return replace(current);
+    }
+
+    @AnyThread
+    @NonNull
+    public AuthState updateAfterRegistration(
+            RegistrationResponse response,
+            AuthorizationException ex) {
+        AuthState current = getCurrent();
+        if (ex != null) {
+            return current;
+        }
+
+        current.update(response);
+        return replace(current);
+    }
+
+    @AnyThread
+    @NonNull
+    private AuthState readState() {
+        mPrefsLock.lock();
+        try {
+            String currentState = mPrefs.getString(KEY_STATE, null);
+            if (currentState == null) {
+                return new AuthState();
+            }
+
+            try {
+                return AuthState.jsonDeserialize(currentState);
+            } catch (JSONException ex) {
+                Log.w(TAG, "Failed to deserialize stored auth state - discarding");
+                return new AuthState();
+            }
+        } finally {
+            mPrefsLock.unlock();
+        }
+    }
+
+    @AnyThread
+    private void writeState(@Nullable AuthState state) {
+        mPrefsLock.lock();
+        try {
+            SharedPreferences.Editor editor = mPrefs.edit();
+            if (state == null) {
+                editor.remove(KEY_STATE);
+            } else {
+                editor.putString(KEY_STATE, state.jsonSerializeString());
+            }
+
+            if (!editor.commit()) {
+                throw new IllegalStateException("Failed to write state to shared prefs");
+            }
+        } finally {
+            mPrefsLock.unlock();
+        }
+    }
+}
+

--- a/app/src/main/java/com/m/helper/Client.java
+++ b/app/src/main/java/com/m/helper/Client.java
@@ -1,4 +1,4 @@
-package com.m.androidNativeApp;
+package com.m.helper;
 
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.subscription.WebSocketSubscriptionTransport;
@@ -7,22 +7,32 @@ import java.util.HashMap;
 import java.util.Map;
 
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 public class Client {
 
-    public static ApolloClient setupApollo(String serverUrl) {
+    public static ApolloClient setupApollo(String serverUrl, String authHeader) {
+
+
         OkHttpClient okHttpClient = new OkHttpClient
                 .Builder()
+                .addInterceptor(chain -> {
+                    Request original = chain.request();
+                    Request.Builder builder = original.newBuilder().method(original.method(), original.body());
+                    builder.header("Authorization", authHeader);
+                    return chain.proceed(builder.build());
+                })
                 .build();
 
         Map<String, Object> connectionParams = new HashMap<>();
+        connectionParams.put("Authorization", authHeader);
 
-        System.out.println("APP: In Client: url: " + serverUrl);
         return ApolloClient.builder()
                 .serverUrl(serverUrl)
                 .subscriptionConnectionParams(connectionParams)
                 .subscriptionTransportFactory(new WebSocketSubscriptionTransport.Factory(serverUrl, okHttpClient))
                 .okHttpClient(okHttpClient)
                 .build();
+
     }
 }

--- a/app/src/main/java/com/m/helper/Client.java
+++ b/app/src/main/java/com/m/helper/Client.java
@@ -13,7 +13,6 @@ public class Client {
 
     public static ApolloClient setupApollo(String serverUrl, String authHeader) {
 
-
         OkHttpClient okHttpClient = new OkHttpClient
                 .Builder()
                 .addInterceptor(chain -> {

--- a/app/src/main/java/com/m/helper/CreateTask.java
+++ b/app/src/main/java/com/m/helper/CreateTask.java
@@ -1,4 +1,4 @@
-package com.m.androidNativeApp;
+package com.m.helper;
 
 import android.app.Activity;
 import android.os.Bundle;
@@ -8,10 +8,13 @@ import android.widget.EditText;
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
+import com.m.androidNativeApp.CreateTaskMutation;
+import com.m.androidNativeApp.R;
 
 import org.jetbrains.annotations.NotNull;
 
 import static com.m.androidNativeApp.MainActivity.client;
+
 
 public class CreateTask extends Activity {
 
@@ -42,7 +45,6 @@ public class CreateTask extends Activity {
 
             }
         });
-
         finish();
     }
 }

--- a/app/src/main/java/com/m/helper/CreateTask.java
+++ b/app/src/main/java/com/m/helper/CreateTask.java
@@ -26,8 +26,8 @@ public class CreateTask extends Activity {
     }
 
     public void createTask(View view) {
-        EditText taskTitle = (EditText) findViewById(R.id.title_input);
-        EditText taskDescription = (EditText) findViewById(R.id.description_input);
+        EditText taskTitle = findViewById(R.id.title_input);
+        EditText taskDescription = findViewById(R.id.description_input);
 
         CreateTaskMutation createTask = CreateTaskMutation
                 .builder()

--- a/app/src/main/java/com/m/helper/CreateTask.java
+++ b/app/src/main/java/com/m/helper/CreateTask.java
@@ -1,6 +1,7 @@
 package com.m.helper;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
@@ -12,8 +13,8 @@ import com.m.androidNativeApp.CreateTaskMutation;
 import com.m.androidNativeApp.R;
 
 import org.jetbrains.annotations.NotNull;
-
 import static com.m.androidNativeApp.MainActivity.client;
+import static com.m.helper.LoginActivity.RE_AUTH;
 
 
 public class CreateTask extends Activity {
@@ -42,9 +43,14 @@ public class CreateTask extends Activity {
 
             @Override
             public void onFailure(@NotNull ApolloException e) {
-
+                if (e.getMessage().equals("HTTP 403 Forbidden")) {
+                    RE_AUTH = 403;
+                    Intent redirectToRefreshToken = new Intent(CreateTask.this, LoginActivity.class);
+                    startActivity(redirectToRefreshToken);
+                }
             }
         });
+
         finish();
     }
 }

--- a/app/src/main/java/com/m/helper/Item.java
+++ b/app/src/main/java/com/m/helper/Item.java
@@ -1,4 +1,4 @@
-package com.m.androidNativeApp;
+package com.m.helper;
 
 public class Item {
 

--- a/app/src/main/java/com/m/helper/ItemAdapter.java
+++ b/app/src/main/java/com/m/helper/ItemAdapter.java
@@ -1,4 +1,4 @@
-package com.m.androidNativeApp;
+package com.m.helper;
 
 import android.content.Context;
 import android.view.LayoutInflater;
@@ -9,6 +9,8 @@ import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.m.androidNativeApp.R;
 
 import java.util.List;
 

--- a/app/src/main/java/com/m/helper/LoginActivity.java
+++ b/app/src/main/java/com/m/helper/LoginActivity.java
@@ -1,0 +1,125 @@
+package com.m.helper;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.m.helper.Auth.AuthStateManager;
+import com.m.androidNativeApp.MainActivity;
+
+import net.openid.appauth.AuthState;
+import net.openid.appauth.AuthorizationException;
+import net.openid.appauth.AuthorizationResponse;
+import net.openid.appauth.AuthorizationService;
+import net.openid.appauth.AuthorizationServiceConfiguration;
+import net.openid.appauth.AuthorizationRequest;
+import net.openid.appauth.ResponseTypeValues;
+import net.openid.appauth.TokenRequest;
+import net.openid.appauth.TokenResponse;
+
+public class LoginActivity extends AppCompatActivity {
+
+    private String K_REDIRECT_URI = "com.m.androidnativeapp:/oauth2redirect";
+    private int RC_AUTH = 100;
+    private static AuthState mAuthState;
+    private AuthorizationService mAuthService;
+    private AuthStateManager mAuthStateManager;
+    private MobileService mobileService;
+    private Context context;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mAuthStateManager = AuthStateManager.getInstance(this);
+        context = getApplicationContext();
+        mobileService = MobileService.getInstance(context.getApplicationContext());
+
+        if (mAuthStateManager.getCurrent().isAuthorized()) {
+            mAuthStateManager.getCurrent().createTokenRefreshRequest();
+            System.out.println("User is authorized already");
+
+            startActivity(new Intent(this, MainActivity.class));
+            finish();
+
+
+        } else {
+            mAuthService = new AuthorizationService(this);
+            doAuth();
+        }
+    }
+
+    public void doAuth() {
+
+        final AuthorizationServiceConfiguration.RetrieveConfigurationCallback retrieveCallback =
+                (authorizationServiceConfiguration, e) -> {
+                    if (e != null) {
+                        System.out.println("Failed to retrieve configuration for " + mobileService.getKIssuer());
+                    } else {
+                        makeAuthRequest(authorizationServiceConfiguration);
+                    }
+                };
+
+        String discoveryEndpoint = mobileService.getKIssuer() + ".well-known/openid-configuration";
+        AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(discoveryEndpoint), retrieveCallback);
+    }
+
+    public void makeAuthRequest(AuthorizationServiceConfiguration serviceConfiguration) {
+        AuthorizationRequest.Builder authorizationRequest = new AuthorizationRequest.Builder(
+                serviceConfiguration,
+                mobileService.getKClientId(),
+                ResponseTypeValues.CODE,
+                Uri.parse(K_REDIRECT_URI));
+        AuthorizationRequest authRequest = authorizationRequest.build();
+        Intent authIntent = mAuthService.getAuthorizationRequestIntent(authRequest);
+        startActivityForResult(authIntent, RC_AUTH);
+
+    }
+
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RC_AUTH) {
+            AuthorizationResponse resp = AuthorizationResponse.fromIntent(data);
+            AuthorizationException ex = AuthorizationException.fromIntent(data);
+            mAuthStateManager.updateAfterAuthorization(resp, ex);
+            mAuthState = new AuthState(resp, ex);
+
+            exchangeAuthorizationCode(resp);
+
+
+        } else {
+            System.out.println("Error, wrong response code");
+        }
+    }
+
+    private void exchangeAuthorizationCode(AuthorizationResponse authorizationResponse) {
+        performTokenRequest(authorizationResponse.createTokenExchangeRequest());
+    }
+
+    private void performTokenRequest(TokenRequest request) {
+        mAuthService.performTokenRequest(
+                request,
+                new AuthorizationService.TokenResponseCallback() {
+                    @Override
+                    public void onTokenRequestCompleted(
+                            @Nullable TokenResponse tokenResponse,
+                            @Nullable AuthorizationException ex) {
+                        receivedTokenResponse(tokenResponse, ex);
+                        mAuthStateManager.updateAfterTokenResponse(tokenResponse, ex);
+                    }
+                });
+    }
+
+    private void receivedTokenResponse(
+            @Nullable TokenResponse tokenResponse,
+            @Nullable AuthorizationException authException) {
+        mAuthState.update(tokenResponse, authException);
+        startActivity(new Intent(this, MainActivity.class));
+    }
+
+}

--- a/app/src/main/java/com/m/helper/LoginActivity.java
+++ b/app/src/main/java/com/m/helper/LoginActivity.java
@@ -100,14 +100,9 @@ public class LoginActivity extends AppCompatActivity {
     private void performTokenRequest(TokenRequest request) {
         mAuthService.performTokenRequest(
                 request,
-                new AuthorizationService.TokenResponseCallback() {
-                    @Override
-                    public void onTokenRequestCompleted(
-                            @Nullable TokenResponse tokenResponse,
-                            @Nullable AuthorizationException ex) {
-                        receivedTokenResponse(tokenResponse, ex);
-                        mAuthStateManager.updateAfterTokenResponse(tokenResponse, ex);
-                    }
+                (tokenResponse, ex) -> {
+                    receivedTokenResponse(tokenResponse, ex);
+                    mAuthStateManager.updateAfterTokenResponse(tokenResponse, ex);
                 });
     }
 

--- a/app/src/main/java/com/m/helper/MobileService.java
+++ b/app/src/main/java/com/m/helper/MobileService.java
@@ -35,7 +35,7 @@ public class MobileService implements IMobileService {
 
     private final String FILE_LOCATION = "config/mobile-services.json";
 
-    private MobileService(Context context){
+    private MobileService(Context context) {
         System.out.println("APP : Setting up Mobile Services");
         assetManager = context.getAssets();
         readMobileServiceJSON();
@@ -86,7 +86,7 @@ public class MobileService implements IMobileService {
         return service.getConfig().getVariantSecret();
     }
 
-    private void readMobileServiceJSON(){
+    private void readMobileServiceJSON() {
         try {
             BufferedReader bufferedReader = getBufferReader();
             JsonObject array = getJsonObject(bufferedReader);
@@ -106,7 +106,7 @@ public class MobileService implements IMobileService {
         }
     }
 
-    private Service buildService(JsonObject service){
+    private Service buildService(JsonObject service) {
         Service result = null;
         switch (service.get("type").getAsString()) {
             case SYNC_APP:
@@ -136,15 +136,15 @@ public class MobileService implements IMobileService {
         return new BufferedReader(inputStreamReader);
     }
 
-    private JsonObject getJsonObject(BufferedReader bufferedReader){
+    private JsonObject getJsonObject(BufferedReader bufferedReader) {
         JsonParser parser = new JsonParser();
         return parser.parse(bufferedReader).getAsJsonObject();
     }
 
     private void configureServices(JsonArray services) {
-        for (int i = 0; i < services.size(); i++){
+        for (int i = 0; i < services.size(); i++) {
             Service newService = buildService(services.get(i).getAsJsonObject());
-            if (newService != null){
+            if (newService != null) {
                 config.addService(newService);
             } else {
                 System.out.println("APP: Service was null");

--- a/app/src/main/res/layout/login_activity.xml
+++ b/app/src/main/res/layout/login_activity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</LinearLayout>


### PR DESCRIPTION
### Summary

Implementation of AppAuth. On the initial screen, the client is redirected to KeyCloak. We are using OpenID connect discovery document. 
Next, we are building the auth request. Once we get a response from the auth request we are sending a request for a token. The token is then passed to the ApolloClient and we are using it to interact with the server that has keycloak implemented. 

### To test

1. Paste your `mobile.services.json` file into `assets/config` file.
2. Run application on mutliple devices
3. Log in
4. Interact with server by adding and removing tasks
5. Close the app
6. Re-open - you should not be asked to log in again. 

NOTE: Leaving it as draft for now although all the functionalities are working as the app at  the moment does not check if the token is still valid, once token timer is expired, you won't be asked to log in but you won't see any data coming back from the server neither.

UPDATE: When client is logged out from keycloak app redirects to log in page. If client token is expired but is still logged in to keycloak token is refreshed. 
