### PR TITLE
feat: add support for androidPie

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name="com.m.helper.LoginActivity">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">com.m.androidNativeApp</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
### Summary

Using`http` server URL does not work with Android Pie devices. This PR fixes the issue and enables testing the app with `http` servers on Android Pie devices.
