### PR TITLE
DataSync refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.apollographql.apollo:apollo-runtime:1.2.0'
     implementation "com.apollographql.apollo:apollo-android-support:1.2.0"
     implementation 'com.squareup.okhttp3:okhttp:3.12.2'
+    implementation 'com.apollographql.apollo:apollo-http-cache:1.2.1'
     testImplementation 'junit:junit:4.12'
     compileOnly 'org.jetbrains:annotations:13.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name="com.m.helper.LoginActivity">

--- a/app/src/main/assets/config/mobile-services.json
+++ b/app/src/main/assets/config/mobile-services.json
@@ -4,38 +4,26 @@
   "services": [
     {
       "config": {
-        "auth-server-url": "https://sso-user-sso.apps.ire-85ac.open.redhat.com/auth",
+        "auth-server-url": "https://sso-user-sso.apps.ire-219e.open.redhat.com/auth",
         "confidential-port": 0,
         "public-client": true,
         "realm": "androidapp-realm",
         "resource": "androidapp-client",
         "ssl-required": "external"
       },
-      "id": "4a54df0d-007d-11ea-88e3-022694327861",
+      "id": "136bee8b-047c-11ea-ab9a-067548568095",
       "name": "keycloak",
       "type": "keycloak",
-      "url": "https://sso-user-sso.apps.ire-85ac.open.redhat.com/auth"
+      "url": "https://sso-user-sso.apps.ire-219e.open.redhat.com/auth"
     },
     {
       "config": {
-        "websocketUrl": "wss://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-85ac.open.redhat.com/graphql"
+        "websocketUrl": "wss://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-219e.open.redhat.com/graphql"
       },
-      "id": "94dcaf15-fbd3-11e9-8869-022694327861",
+      "id": "0f12d02b-047c-11ea-ab9a-067548568095",
       "name": "sync-app",
       "type": "sync-app",
-      "url": "https://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-85ac.open.redhat.com/graphql"
-    },
-    {
-      "config": {
-        "android": {
-          "variantId": "9e505d21-3179-4aea-a0de-66edb0a494d5",
-          "variantSecret": "ceae64c6-cee4-4677-b6b0-29b9c82d3ae1"
-        }
-      },
-      "id": "48725258-ffb8-11e9-95d0-022694327861",
-      "name": "push",
-      "type": "push",
-      "url": "https://unifiedpush-unifiedpush-proxy-mobile-unifiedpush.apps.ire-85ac.open.redhat.com"
+      "url": "https://ionic-showcase-server-customer-a-shar-b4c5.apps.ire-219e.open.redhat.com/graphql"
     }
   ]
 }

--- a/app/src/main/java/com/m/androidNativeApp/MainActivity.java
+++ b/app/src/main/java/com/m/androidNativeApp/MainActivity.java
@@ -223,9 +223,6 @@ public class MainActivity extends AppCompatActivity {
                             itemList.add(new Item(taskTitle, taskDescription, taskId));
                         }
 
-
-                        client.apolloStore().read(tasksQuery);
-
                         runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
                     }
 

--- a/app/src/main/java/com/m/androidNativeApp/MainActivity.java
+++ b/app/src/main/java/com/m/androidNativeApp/MainActivity.java
@@ -6,7 +6,10 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
 
+import android.content.Context;
 import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -16,6 +19,8 @@ import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.ApolloSubscriptionCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
+import com.apollographql.apollo.fetcher.ResponseFetcher;
 import com.m.helper.Client;
 import com.m.helper.CreateTask;
 import com.m.helper.Item;
@@ -24,6 +29,7 @@ import com.m.androidNativeApp.fragment.TaskFields;
 import com.m.helper.LoginActivity;
 
 import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 
 import static com.m.helper.LoginActivity.RE_AUTH;
@@ -32,7 +38,6 @@ import static com.m.helper.LoginActivity.mobileService;
 
 
 public class MainActivity extends AppCompatActivity {
-
     public static ApolloClient client;
     private String taskTitle, taskDescription, taskId;
     private RecyclerView recyclerView;
@@ -43,8 +48,8 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
         setupClient();
+
         itemAdapter = getAdapter();
 
         MainActivity.this.runOnUiThread(() -> recyclerView.setAdapter(itemAdapter));
@@ -55,84 +60,93 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void subscribeToDeleteTask() {
+
         DeleteTaskSubscription deleteTaskSubscription = DeleteTaskSubscription
                 .builder()
                 .build();
 
-        client.subscribe(deleteTaskSubscription).execute(new ApolloSubscriptionCall.Callback<DeleteTaskSubscription.Data>() {
-            @Override
-            public void onResponse(@NotNull Response<DeleteTaskSubscription.Data> response) {
-                for (Item item : itemList) {
-                    if (item.getId().equals(response.data().taskDeleted.fragments().taskFields.id())) {
-                        itemList.remove(item);
-                        break;
+        client.subscribe(deleteTaskSubscription)
+                .execute(new ApolloSubscriptionCall.Callback<DeleteTaskSubscription.Data>() {
+                    @Override
+                    public void onResponse(@NotNull Response<DeleteTaskSubscription.Data> response) {
+
+                        for (Item item : itemList) {
+                            if (item.getId().equals(response.data().taskDeleted.fragments().taskFields.id())) {
+                                itemList.remove(item);
+                                break;
+                            }
+                        }
+
+
+                        runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
+
                     }
-                }
 
-                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
+                    @Override
+                    public void onFailure(@NotNull ApolloException e) {
+                        if (e.getMessage().equals("HTTP 403 Forbidden")) {
+                            reAuthorise();
+                        }
+                    }
 
-            }
+                    @Override
+                    public void onCompleted() {
+                        System.out.println("Subscribed to DeleteTask");
+                    }
 
-            @Override
-            public void onFailure(@NotNull ApolloException e) {
-                if (e.getMessage().equals("HTTP 403 Forbidden")) {
-                    reAuthorise();
-                }
-            }
+                    @Override
+                    public void onTerminated() {
+                        System.out.println("DeleteTask subscription terminated");
+                    }
 
-            @Override
-            public void onCompleted() {
-                System.out.println("Subscribed to DeleteTask");
-            }
-
-            @Override
-            public void onTerminated() {
-                System.out.println("DeleteTask subscription terminated");
-            }
-
-            @Override
-            public void onConnected() {
-                System.out.println("Connected to DeleteTask subscription");
-            }
-        });
+                    @Override
+                    public void onConnected() {
+                        System.out.println("Connected to DeleteTask subscription");
+                    }
+                });
     }
 
     public void subscribeToAddTask() {
+
+
         AddTaskSubscription addTaskSubscription = AddTaskSubscription
                 .builder()
                 .build();
 
-        client.subscribe(addTaskSubscription).execute(new ApolloSubscriptionCall.Callback<AddTaskSubscription.Data>() {
-            @Override
-            public void onResponse(@NotNull Response<AddTaskSubscription.Data> response) {
-                TaskFields dataReceived = response.data().taskAdded().fragments().taskFields;
-                itemList.add(new Item(dataReceived.title(), dataReceived.description(), dataReceived.id()));
+        client.subscribe(addTaskSubscription)
+                .execute(new ApolloSubscriptionCall.Callback<AddTaskSubscription.Data>() {
+                    @Override
+                    public void onResponse(@NotNull Response<AddTaskSubscription.Data> response) {
 
-                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
-            }
+                        TaskFields dataReceived = response.data().taskAdded().fragments().taskFields;
+                        itemList.add(new Item(dataReceived.title(), dataReceived.description(), dataReceived.id()));
 
-            @Override
-            public void onFailure(@NotNull ApolloException e) {
-                if (e.getMessage().equals("HTTP 403 Forbidden")) {
-                    reAuthorise();
-                }
-            }
 
-            @Override
-            public void onCompleted() {
-                System.out.println("Subscribed to AddTask");
-            }
+                        runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
+                    }
 
-            @Override
-            public void onTerminated() {
-                System.out.println("AddTask subscription terminated");
-            }
+                    @Override
+                    public void onFailure(@NotNull ApolloException e) {
+                        if (e.getMessage().equals("HTTP 403 Forbidden")) {
+                            reAuthorise();
+                        }
+                    }
 
-            @Override
-            public void onConnected() {
-                System.out.println("Connected to AddTask subscription");
-            }
-        });
+                    @Override
+                    public void onCompleted() {
+                        System.out.println("Subscribed to AddTask");
+                    }
+
+                    @Override
+                    public void onTerminated() {
+                        System.out.println("AddTask subscription terminated");
+                    }
+
+                    @Override
+                    public void onConnected() {
+                        System.out.println("Connected to AddTask subscription");
+                    }
+                });
 
     }
 
@@ -142,33 +156,40 @@ public class MainActivity extends AppCompatActivity {
 
         final String buttonId = button.getTag().toString();
 
+        AllTasksQuery tasksQuery = AllTasksQuery
+                .builder()
+                .build();
+        client.query(tasksQuery);
+
         DeleteTaskMutation deleteTask = DeleteTaskMutation
                 .builder()
                 .id(buttonId)
                 .build();
 
-        client.mutate(deleteTask).enqueue(new ApolloCall.Callback<DeleteTaskMutation.Data>() {
-            @Override
-            public void onResponse(@NotNull final Response<DeleteTaskMutation.Data> response) {
+        client.mutate(deleteTask)
+                .refetchQueries(tasksQuery)
+                .enqueue(new ApolloCall.Callback<DeleteTaskMutation.Data>() {
+                    @Override
+                    public void onResponse(@NotNull final Response<DeleteTaskMutation.Data> response) {
 
-                for (Item item : itemList) {
-                    if (response.data() != null && item.getId().equals(response.data().deleteTask())) {
-                        itemList.remove(item);
-                        break;
+                        for (Item item : itemList) {
+                            if (response.data() != null && item.getId().equals(response.data().deleteTask())) {
+                                itemList.remove(item);
+                                break;
+                            }
+                        }
+
+                        runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
+
                     }
-                }
 
-                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
-
-            }
-
-            @Override
-            public void onFailure(@NotNull ApolloException e) {
-                if (e.getMessage().equals("HTTP 403 Forbidden")) {
-                    reAuthorise();
-                }
-            }
-        });
+                    @Override
+                    public void onFailure(@NotNull ApolloException e) {
+                        if (e.getMessage().equals("HTTP 403 Forbidden")) {
+                            reAuthorise();
+                        }
+                    }
+                });
     }
 
     public void addTaskActivity(View view) {
@@ -178,51 +199,73 @@ public class MainActivity extends AppCompatActivity {
 
     public void getTasks() {
 
+        ResponseFetcher onlineResponse = ApolloResponseFetchers.NETWORK_ONLY;
+
+        if (!isOnline()) {
+            onlineResponse = ApolloResponseFetchers.CACHE_ONLY;
+        }
+
         AllTasksQuery tasksQuery = AllTasksQuery
                 .builder()
                 .build();
 
-        client.query(tasksQuery).enqueue(new ApolloCall.Callback<AllTasksQuery.Data>() {
-            @Override
-            public void onResponse(@NotNull Response<AllTasksQuery.Data> response) {
-                final int dataLength = response.data().allTasks().size();
+        client.query(tasksQuery)
+                .responseFetcher(onlineResponse)
+                .enqueue(new ApolloCall.Callback<AllTasksQuery.Data>() {
+                    @Override
+                    public void onResponse(@NotNull Response<AllTasksQuery.Data> response) {
+                        final int dataLength = response.data().allTasks().size();
+                        for (int i = 0; i < dataLength; i++) {
+                            TaskFields dataReceived = response.data().allTasks().get(i).fragments().taskFields();
+                            taskTitle = dataReceived.title();
+                            taskDescription = dataReceived.description();
+                            taskId = dataReceived.id();
+                            itemList.add(new Item(taskTitle, taskDescription, taskId));
+                        }
 
-                for (int i = 0; i < dataLength; i++) {
-                    TaskFields dataReceived = response.data().allTasks().get(i).fragments().taskFields();
-                    taskTitle = dataReceived.title();
-                    taskDescription = dataReceived.description();
-                    taskId = dataReceived.id();
-                    itemList.add(new Item(taskTitle, taskDescription, taskId));
-                }
-                runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
-            }
 
-            @Override
-            public void onFailure(@NotNull ApolloException e) {
-                if (e.getMessage().equals("HTTP 403 Forbidden")) {
-                    reAuthorise();
-                }
-            }
-        });
+                        client.apolloStore().read(tasksQuery);
+
+                        runOnUiThread(() -> itemAdapter.notifyDataSetChanged());
+                    }
+
+                    @Override
+                    public void onFailure(@NotNull ApolloException e) {
+                        if (e.getMessage().equals("HTTP 403 Forbidden")) {
+                            reAuthorise();
+                        }
+                    }
+                });
     }
 
-    public void reAuthorise(){
+    public void reAuthorise() {
         RE_AUTH = 403;
         Intent redirectToRefreshToken = new Intent(MainActivity.this, LoginActivity.class);
         startActivity(redirectToRefreshToken);
     }
 
-    public void setupClient(){
+    public void setupClient() {
         String token = "Bearer " + mAuthStateManager.getCurrent().getAccessToken();
-        client = Client.setupApollo(mobileService.getGraphqlServer(), token);
+        client = Client.setupApollo(mobileService.getGraphqlServer(), token, getApplicationContext());
     }
 
-    public ItemAdapter getAdapter(){
+    public ItemAdapter getAdapter() {
         itemList = new ArrayList<>();
         recyclerView = findViewById(R.id.recyclerView);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         itemAdapter = new ItemAdapter(this, itemList);
 
         return itemAdapter;
+    }
+
+    public boolean isOnline() {
+        ConnectivityManager connManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connManager.getActiveNetworkInfo();
+
+        if (networkInfo != null && networkInfo.isConnectedOrConnecting()) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/app/src/main/java/com/m/helper/Client.java
+++ b/app/src/main/java/com/m/helper/Client.java
@@ -1,7 +1,21 @@
 package com.m.helper;
 
+import android.content.Context;
+
 import com.apollographql.apollo.ApolloClient;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseField;
+import com.apollographql.apollo.cache.normalized.CacheKey;
+import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
+import com.apollographql.apollo.cache.normalized.NormalizedCacheFactory;
+import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy;
+import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCache;
+import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory;
+import com.apollographql.apollo.cache.normalized.sql.ApolloSqlHelper;
+import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory;
 import com.apollographql.apollo.subscription.WebSocketSubscriptionTransport;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +25,36 @@ import okhttp3.Request;
 
 public class Client {
 
-    public static ApolloClient setupApollo(String serverUrl, String authHeader) {
+    public static ApolloClient setupApollo(String serverUrl, String authHeader, Context context) {
+
+
+        CacheKeyResolver resolver = new CacheKeyResolver() {
+            @NotNull
+            @Override
+            public CacheKey fromFieldRecordSet(@NotNull ResponseField field, @NotNull Map<String, Object> recordSet) {
+                return formatCacheKey((String) recordSet.get("id"));
+            }
+
+            @NotNull
+            @Override
+            public CacheKey fromFieldArguments(@NotNull ResponseField field, @NotNull Operation.Variables variables) {
+                return formatCacheKey((String) field.resolveArgument("id", variables));
+            }
+
+            private CacheKey formatCacheKey(String id) {
+                if (id == null || id.isEmpty()) {
+                    return CacheKey.NO_KEY;
+                } else {
+                    return CacheKey.from(id);
+                }
+            }
+        };
+
+        String DB_CACHE_NAME = "myapp";
+        ApolloSqlHelper apolloSqlHelper = new ApolloSqlHelper(context, DB_CACHE_NAME);
+
+        NormalizedCacheFactory<LruNormalizedCache> cacheFactory = new LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION)
+                .chain(new SqlNormalizedCacheFactory(apolloSqlHelper));
 
         OkHttpClient okHttpClient = new OkHttpClient
                 .Builder()
@@ -27,11 +70,12 @@ public class Client {
         connectionParams.put("Authorization", authHeader);
 
         return ApolloClient.builder()
+                .enableAutoPersistedQueries(true)
                 .serverUrl(serverUrl)
+                .normalizedCache(cacheFactory, resolver)
                 .subscriptionConnectionParams(connectionParams)
                 .subscriptionTransportFactory(new WebSocketSubscriptionTransport.Factory(serverUrl, okHttpClient))
                 .okHttpClient(okHttpClient)
                 .build();
-
     }
 }

--- a/app/src/main/java/com/m/helper/CreateTask.java
+++ b/app/src/main/java/com/m/helper/CreateTask.java
@@ -10,9 +10,11 @@ import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import com.m.androidNativeApp.CreateTaskMutation;
+import com.m.androidNativeApp.MainActivity;
 import com.m.androidNativeApp.R;
 
 import org.jetbrains.annotations.NotNull;
+
 import static com.m.androidNativeApp.MainActivity.client;
 import static com.m.helper.LoginActivity.RE_AUTH;
 
@@ -51,6 +53,7 @@ public class CreateTask extends Activity {
             }
         });
 
-        finish();
+        Intent redirectToRefreshToken = new Intent(CreateTask.this, MainActivity.class);
+        startActivity(redirectToRefreshToken);
     }
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">com.m.androidNativeApp</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
### Summary

Our current client does not use any kind of cache for caching apollo queries. This PR enables normalized cache.

### How to test

1. Run the app
2. Add few tasks 
3. Switch the device offline ( switching to "Flight" mode does not always switch the device offline, suggest to use `adb data disable` along with `adb wifi disable` for the emulated device
4. Close the app and re-open
5. All added tasks should be visible.

### How it works

#### Reading from cache

Before each `get all tasks` query app checks if the device is offline or online. If online fetch policy is set to `NETWORK_ONLY` and if the device is offline, it reads from the normalized cache.

#### Saving to cache

Data is saved to cache every time `get all tasks` is executed. When `delete` mutation is executed we are executing Apollo's `refetchQueries` which is a function that allows you to specify which queries you want to refetch after a mutation has occurred. Adding a task simply refreshes the fetch queries.

Currently there is no support for subscriptions and saving to cache as for it to work, we would need to use `subscribeToMore`, however, from what I've gathered - `subscribeToMore` is not supported for Apollo with Java.